### PR TITLE
#52 Add ability to specify file path for Manual provider

### DIFF
--- a/ACMESharp/ACMESharp.POSH/ACMESharp.POSH.csproj
+++ b/ACMESharp/ACMESharp.POSH/ACMESharp.POSH.csproj
@@ -62,6 +62,7 @@
     <Compile Include="NewCertificate.cs" />
     <Compile Include="NewIdentifier.cs" />
     <Compile Include="NewProviderConfig.cs" />
+    <Compile Include="ProviderConfigDto.cs" />
     <Compile Include="ProviderConfigSamples\Loader.cs" />
     <Compile Include="SetProxy.cs" />
     <Compile Include="SetServerDirectory.cs" />

--- a/ACMESharp/ACMESharp.POSH/NewProviderConfig.cs
+++ b/ACMESharp/ACMESharp.POSH/NewProviderConfig.cs
@@ -5,6 +5,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Management.Automation;
 using System.Text;
+using Newtonsoft.Json;
 
 namespace ACMESharp.POSH
 {
@@ -98,15 +99,21 @@ namespace ACMESharp.POSH
                 }
                 else
                 {
-                    using (var reader = new StreamReader(s))
+                    var config = new ProviderConfigDto
                     {
-                        var text = reader.ReadToEnd();
-                        text = text.Replace(@".\\path\\to\\web-content-file", FilePath);
-                        s = new MemoryStream(Encoding.UTF8.GetBytes(text));
-                        using (var fs = new FileStream(temp, FileMode.Create))
+                        Provider = new Provider
                         {
-                            s.CopyTo(fs);
+                            Type = "ACMESharp.WebServer.ManualWebServerProvider, ACMESharp",
+                            FilePath = FilePath
                         }
+                    };
+
+                    var output = JsonConvert.SerializeObject(config);
+
+                    s = new MemoryStream(Encoding.UTF8.GetBytes(output));
+                    using (var fs = new FileStream(temp, FileMode.Create))
+                    {
+                        s.CopyTo(fs);
                     }
                 }
 

--- a/ACMESharp/ACMESharp.POSH/ProviderConfigDto.cs
+++ b/ACMESharp/ACMESharp.POSH/ProviderConfigDto.cs
@@ -1,0 +1,18 @@
+﻿using Newtonsoft.Json;
+
+namespace ACMESharp.POSH
+{
+    public class ProviderConfigDto
+    {
+        public Provider Provider { get; set; }
+    }
+
+    public class Provider
+    {
+        [JsonProperty("$type")]
+        public string Type { get; set; }
+
+        [JsonProperty("FilePath")]
+        public string FilePath { get; set; }
+    }
+}

--- a/ACMESharp/ACMESharp.POSH/Vault/ProviderConfig.cs
+++ b/ACMESharp/ACMESharp.POSH/Vault/ProviderConfig.cs
@@ -22,5 +22,8 @@ namespace ACMESharp.POSH.Vault
 
         public string WebServerProvider
         { get; set; }
+
+        public string FilePath
+        { get; set; }
     }
 }


### PR DESCRIPTION
This is a little hacky, but this part of the code already seems a little hacky to start with ;-)

Works well though, and I can now specify a path and do a complete end-to-end request for certificate without touching the keyboard!