### PR TITLE
NewRegistration POCO Important FIX and Greater Flexibility for FileVaultProfile

### DIFF
--- a/ACMESharp/ACMESharp.POSH/Vault/FileVaultProvider.cs
+++ b/ACMESharp/ACMESharp.POSH/Vault/FileVaultProvider.cs
@@ -88,7 +88,9 @@ namespace ACMESharp.POSH.Vault
             if (string.IsNullOrEmpty(RootPath))
                 RootPath = psCwd;
 
-            RootPath = Path.GetFullPath(Path.Combine(psCwd, RootPath));
+            // Optional Fix , Allows VaultProfile to be a full path and not relative to the current working path.
+            if (Path.IsPathRooted(RootPath) == false)
+                RootPath = Path.GetFullPath(Path.Combine(psCwd, RootPath));
 
             // If the Root and CWD aren't the same, we need to
             // temporarily move the CWD while we're working

--- a/ACMESharp/ACMESharp/AcmeClient.cs
+++ b/ACMESharp/ACMESharp/AcmeClient.cs
@@ -146,9 +146,10 @@ namespace ACMESharp
         {
             AssertInit();
 
+            //  Extremely Important FIX! The LetsEncrypt API at this stage does not accept CONTACT as field but CONTACTS (in plural) will be accepted
             var requMsg = new NewRegRequest
             {
-                Contact = contacts,
+                Contacts = contacts,
             };
 
             var resp = RequestHttpPost(new Uri(RootUrl,
@@ -198,8 +199,9 @@ namespace ACMESharp
 
             var requMsg = new UpdateRegRequest();
 
-            if (contacts != null)
-                requMsg.Contact = contacts;
+            if (contacts != null) 
+                requMsg.Contacts = contacts;
+            //  Extremely Important FIX! The LetsEncrypt API at this stage does not accept CONTACT as field but CONTACTS (in plural) will be accepted
 
             if (agreeToTos && !string.IsNullOrWhiteSpace(Registration.TosLinkUri))
                 requMsg.Agreement = Registration.TosLinkUri;

--- a/ACMESharp/ACMESharp/Messages/NewRegRequest.cs
+++ b/ACMESharp/ACMESharp/Messages/NewRegRequest.cs
@@ -10,7 +10,8 @@ namespace ACMESharp.Messages
         protected NewRegRequest(string resource) : base(resource)
         { }
 
-        public IEnumerable<string> Contact
+        //  Extremely Important FIX! The LetsEncrypt API at this stage does not accept CONTACT as field but CONTACTS (in plural) will be accepted
+        public IEnumerable<string> Contacts 
         { get; set; }
 
         public string Agreement


### PR DESCRIPTION
NewRegistration 
Extremely Important FIX! The LetsEncrypt API at this stage does not accept CONTACT as field but CONTACTS (in plural) will be accepted

FileVaultProfile
Optional Fix , Allows VaultProfile to be a full path and not relative to the current working path.