### PR TITLE
Update to handle spaces in paths

### DIFF
--- a/ACMESharp/ACMESharp.PKI.Providers.OpenSslLib32/mynuget.cmd
+++ b/ACMESharp/ACMESharp.PKI.Providers.OpenSslLib32/mynuget.cmd
@@ -5,4 +5,4 @@
 @SET THIS_DIR=%~dp0
 @SET NUGET=%THIS_DIR%..\nuget-build.cmd
 
-%NUGET% ACMESharp.PKI.Providers.OpenSslLib32
+"%NUGET%" ACMESharp.PKI.Providers.OpenSslLib32

--- a/ACMESharp/ACMESharp.PKI.Providers.OpenSslLib64/mynuget.cmd
+++ b/ACMESharp/ACMESharp.PKI.Providers.OpenSslLib64/mynuget.cmd
@@ -5,4 +5,4 @@
 @SET THIS_DIR=%~dp0
 @SET NUGET=%THIS_DIR%..\nuget-build.cmd
 
-%NUGET% ACMESharp.PKI.Providers.OpenSslLib64
+"%NUGET%" ACMESharp.PKI.Providers.OpenSslLib64

--- a/ACMESharp/ACMESharp.POSH/Util/PoshHelper.cs
+++ b/ACMESharp/ACMESharp.POSH/Util/PoshHelper.cs
@@ -19,8 +19,7 @@ namespace ACMESharp.POSH.Util
             // directory happens to be where the PowerShell binary is
             // running from, not where the ACMESharp PS Module lives
 
-            var baseUri = new Uri(typeof(VaultExtManager).Assembly.CodeBase);
-            var baseDir = Path.GetDirectoryName(baseUri.AbsolutePath);
+            var baseDir = Path.GetDirectoryName(typeof(VaultExtManager).Assembly.Location);
 
             ExtCommon.BaseDirectoryOverride = baseDir;
             ExtCommon.RelativeSearchPathOverride = string.Empty;

--- a/ACMESharp/ACMESharp/mynuget.cmd
+++ b/ACMESharp/ACMESharp/mynuget.cmd
@@ -5,4 +5,4 @@
 @SET THIS_DIR=%~dp0
 @SET NUGET=%THIS_DIR%..\nuget-build.cmd
 
-%NUGET% ACMESharp
+"%NUGET%" ACMESharp


### PR DESCRIPTION
There are four places that require a small adjustment so the location of ACMESharp can be on a path that has spaces in any of the directories.  This pull request identifies the locations and suggests fixes.  

The fix to PoshHelper brings it in line with a similar action performed in ACMESharp/Ext/ExtCommon.cs.
