### PR TITLE
Add support for SAN requests.

### DIFF
--- a/ACMESharp/ACMESharp.PKI.Providers.OpenSslLib32/OpenSslLib32Provider.cs
+++ b/ACMESharp/ACMESharp.PKI.Providers.OpenSslLib32/OpenSslLib32Provider.cs
@@ -351,6 +351,20 @@ namespace ACMESharp.PKI.Providers
             if (!string.IsNullOrEmpty(csrDetails.UniqueIdentifier   /**/)) xn.UniqueIdentifier = csrDetails.UniqueIdentifier; // UID;
 
             var xr = new X509Request(0, xn, rsaKeys);
+            if (csrDetails.AlternativeNames.Count > 0)
+            {
+                OpenSSL.Core.Stack<X509Extension> extensions = new OpenSSL.Core.Stack<X509Extension>();
+                // Add the common name as the first alternate
+                string altNames = "DNS:" + xn.Common;
+                foreach (var name in csrDetails.AlternativeNames)
+                {
+                    altNames += ", DNS:" + name;
+                }
+                extensions.Add(new X509Extension(xr, "subjectAltName", false, altNames));
+
+                xr.AddExtensions(extensions);
+            }
+
             var md = MessageDigest.CreateByName(messageDigest);
             xr.Sign(rsaKeys, md);
             using (var bio = BIO.MemoryBuffer())

--- a/ACMESharp/ACMESharp.PKI.Providers.OpenSslLib64/OpenSslLib64Provider.cs
+++ b/ACMESharp/ACMESharp.PKI.Providers.OpenSslLib64/OpenSslLib64Provider.cs
@@ -351,6 +351,19 @@ namespace ACMESharp.PKI.Providers
             if (!string.IsNullOrEmpty(csrDetails.UniqueIdentifier   /**/)) xn.UniqueIdentifier = csrDetails.UniqueIdentifier; // UID;
 
             var xr = new X509Request(0, xn, rsaKeys);
+            if (csrDetails.AlternativeNames.Count > 0)
+            {
+                OpenSSL.Core.Stack<X509Extension> extensions = new OpenSSL.Core.Stack<X509Extension>();
+                // Add the common name as the first alternate
+                string altNames = "DNS:" + xn.Common;
+                foreach (var name in csrDetails.AlternativeNames)
+                {
+                    altNames += ", DNS:" + name;
+                }
+                extensions.Add(new X509Extension(xr, "subjectAltName", false, altNames));
+
+                xr.AddExtensions(extensions);
+            }
             var md = MessageDigest.CreateByName(messageDigest);
             xr.Sign(rsaKeys, md);
             using (var bio = BIO.MemoryBuffer())

--- a/ACMESharp/ACMESharp/PKI/CsrDetails.cs
+++ b/ACMESharp/ACMESharp/PKI/CsrDetails.cs
@@ -1,10 +1,20 @@
-﻿namespace ACMESharp.PKI
+﻿using System.Collections.Generic;
+
+namespace ACMESharp.PKI
 {
 
     public class CsrDetails
     {
+        public CsrDetails()
+        {
+            AlternativeNames = new List<string>();
+        }
+
         /// <summary>X509 'CN'</summary>
         public string CommonName { get; set; }
+
+        // <summary>X509 extension</summary>
+        public List<string> AlternativeNames { get; set; }
 
         /// <summary>X509 'C'</summary>
         public string Country { get; set; }


### PR DESCRIPTION
- If one or more alternate names are specified set the subjectAltName to the common name + the alternates
- Only supports DNS (hostnames)

This requires the changes I made a pull request| for to openssl-net, https://github.com/openssl-net/openssl-net/pull/35