### PR TITLE
Allowing RSA Key Bits to be passed in

### DIFF
--- a/ACMESharp/ACMESharp.PKI.Providers.OpenSslLib32/OpenSslLibBaseProvider.cs
+++ b/ACMESharp/ACMESharp.PKI.Providers.OpenSslLib32/OpenSslLibBaseProvider.cs
@@ -50,7 +50,12 @@ namespace ACMESharp.PKI.Providers
 
             if (rsaPkParams != null)
             {
-                int bits = RSA_BITS_DEFAULT;
+                int bits;
+                // Bits less than 1024 are weak Ref: http://openssl.org/docs/manmaster/crypto/RSA_generate_key_ex.html
+                if (rsaPkParams.NumBits < 1024)
+                    bits = RSA_BITS_DEFAULT;
+                else
+                    bits = rsaPkParams.NumBits;
 
                 BigNumber e;
                 if (string.IsNullOrEmpty(rsaPkParams.PubExp))

--- a/ACMESharp/ACMESharp/PKI/PrivateKey.cs
+++ b/ACMESharp/ACMESharp/PKI/PrivateKey.cs
@@ -16,7 +16,7 @@
         public delegate int RsaKeyGeneratorCallback(int p, int n, object cbArg);
 
         /// <summary>
-        /// The number of bits in the generated key. If not specified 1024 is used.
+        /// The number of bits in the generated key. If not specified 2048 is used.
         /// </summary>
         public int NumBits
         { get; set; }


### PR DESCRIPTION
If the Numbits for rsaPkParams is set and is less than 1024, use the default bits (currently 2048). Otherwise use the NumBits passed in.
Allows support for https://github.com/Lone-Coder/letsencrypt-win-simple/issues/29
Also, corrected comment on PrivateKey.cs where it incorrectly said the NumBits was defaulted to 1024 when it is defaulted to 2048.