### PR TITLE
Resolved OpenSslCliProvider always exporting CSR for test1.acmetest.letsencrypt.org

### DIFF
--- a/ACMESharp/ACMESharp.PKI.Providers.OpenSslCli/OpenSslCliProvider.cs
+++ b/ACMESharp/ACMESharp.PKI.Providers.OpenSslCli/OpenSslCliProvider.cs
@@ -223,7 +223,6 @@ namespace ACMESharp.PKI.Providers
 
             if (rsaPk != null)
             {
-                var tempCfgFile = Path.GetTempFileName();
                 var tempKeyFile = Path.GetTempFileName();
                 var tempCsrFile = Path.GetTempFileName();
 
@@ -232,7 +231,7 @@ namespace ACMESharp.PKI.Providers
                     var mdVal = Enum.GetName(typeof(Crt.MessageDigest), md);
 
                     var args = $"req -batch -new -keyform PEM -key {tempKeyFile} -{mdVal}";
-                    args += $" -config {tempCfgFile} -outform PEM -out {tempCsrFile} -subj \"";
+                    args += $" -outform PEM -out {tempCsrFile} -subj \"";
 
                     var subjParts = new[]
                     {
@@ -258,21 +257,13 @@ namespace ACMESharp.PKI.Providers
                     args += "\"";
 
                     File.WriteAllText(tempKeyFile, rsaPk.Pem);
-                    using (Stream source = Assembly.GetExecutingAssembly()
-                            .GetManifestResourceStream(typeof(OpenSslCliProvider),
-                                    "OpenSslCliProvider_Config.txt"),
-                            target = new FileStream(tempCfgFile, FileMode.Create))
-                    {
-                        source.CopyTo(target);
-                    }
+                    RunCli(args);
 
-                        RunCli(args);
                     var csr = new Csr(File.ReadAllText(tempCsrFile));
                     return csr;
                 }
                 finally
                 {
-                    File.Delete(tempCfgFile);
                     File.Delete(tempKeyFile);
                     File.Delete(tempCsrFile);
                 }

--- a/ACMESharp/ACMESharp.PKI.Providers.OpenSslCli/OpenSslCliProvider_Config.txt
+++ b/ACMESharp/ACMESharp.PKI.Providers.OpenSslCli/OpenSslCliProvider_Config.txt
@@ -11,7 +11,7 @@
 ## If set to the value no this disables prompting of certificate fields and just takes values
 ## from the config file directly. It also changes the expected format of the distinguished_name
 ## and attributes sections.
-prompt = no
+prompt = yes
 
 ## This specifies the section containing the distinguished name fields to prompt for when
 ## generating a certificate or certificate request. The format is described in the next section.


### PR DESCRIPTION
The OpenSslCliProvider implementation includes the subject information with the -subj argument, but also include the OpenSslCliProvider_Config.txt file for the -config argument. 

OpenSsl will use -config and ignore the -subj argument and generate a CSR for test1.acmetest.letsencrypt.org
