### PR TITLE
MSDNS Provider

### DIFF
--- a/ACMESharp/ACMESharp/ACME/Providers/MSDNSChallengeHandler.cs
+++ b/ACMESharp/ACMESharp/ACME/Providers/MSDNSChallengeHandler.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Management;
+
+namespace ACMESharp.ACME.Providers
+{
+	public class MSDNSChallengeHandler : IChallengeHandler
+	{
+		public bool IsDisposed
+		{
+			get; private set;
+		}
+
+		public void CleanUp(Challenge c)
+		{
+		}
+
+		public void Dispose()
+		{
+			IsDisposed = true;
+		}
+
+		public void Handle(Challenge c)
+		{
+			DnsChallenge dnsChallenge = c as DnsChallenge;
+
+			ManagementScope mgmtScope = new ManagementScope(@"\\.\Root\MicrosoftDNS");
+			ManagementClass mgmtClass = null;
+			ManagementBaseObject mgmtParams = null;
+			ManagementObjectSearcher mgmtSearch = null;
+			ManagementObjectCollection mgmtDNSRecords = null;
+			string strQuery;
+
+			strQuery = string.Format("SELECT * FROM MicrosoftDNS_TXTType WHERE OwnerName = '{0}'", dnsChallenge.RecordName);
+
+			mgmtScope.Connect();
+
+			mgmtSearch = new ManagementObjectSearcher(mgmtScope, new ObjectQuery(strQuery));
+
+			mgmtDNSRecords = mgmtSearch.Get();
+
+			if (mgmtDNSRecords.Count == 1)
+			{
+				foreach (ManagementObject mgmtDNSRecord in mgmtDNSRecords)
+				{
+					mgmtParams = mgmtDNSRecord.GetMethodParameters("modify");
+					mgmtParams["DescriptiveText"] = dnsChallenge.RecordValue;
+
+					mgmtDNSRecord.InvokeMethod("modify", mgmtParams, null);
+
+					break;
+				}
+			}
+			else if (mgmtDNSRecords.Count == 0)
+			{
+				mgmtClass = new ManagementClass(mgmtScope, new ManagementPath("MicrosoftDNS_TXTType"), null);
+
+				mgmtParams = mgmtClass.GetMethodParameters("CreateInstanceFromPropertyData");
+				mgmtParams["DnsServerName"] = Environment.MachineName;
+				mgmtParams["ContainerName"] = dnsChallenge.RecordName.Split('.')[dnsChallenge.RecordName.Split('.').Count() - 2] + "." + dnsChallenge.RecordName.Split('.')[dnsChallenge.RecordName.Split('.').Count() - 1];
+				mgmtParams["OwnerName"] = dnsChallenge.RecordName;
+				mgmtParams["DescriptiveText"] = dnsChallenge.RecordValue;
+
+				mgmtClass.InvokeMethod("CreateInstanceFromPropertyData", mgmtParams, null);
+			}
+			else
+			{
+				throw new InvalidOperationException("There should not be more than one DNS txt record for the name.");
+			}
+		}
+	}
+}

--- a/ACMESharp/ACMESharp/ACME/Providers/MSDNSChallengeHandlerProvider.cs
+++ b/ACMESharp/ACMESharp/ACME/Providers/MSDNSChallengeHandlerProvider.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using ACMESharp.Ext;
+
+namespace ACMESharp.ACME.Providers
+{
+	/// <summary>
+	/// Provider for a Challenge Handler that outputs the manual steps
+	/// needed to be completed by the operator.
+	/// </summary>
+	/// <remarks>
+	/// When the output resolves to a file and that file already exists,
+	/// unless either the Append or Overwrite parameters are specified
+	/// as true, an exception will be raised.
+	/// </remarks>
+	[ChallengeHandlerProvider("msdns",
+		ChallengeTypeKind.DNS,
+		Label = "Microsoft DNS Provider",
+		Description = "A microsoft dns provider for handling Challenges." +
+					  " This provider supports the DNS" +
+					  " Challenge type and computes all the necessary" +
+					  " response values. It will create DNS entries.")]
+	public class MSDNSChallengeHandlerProvider : IChallengeHandlerProvider
+	{
+		private static readonly ParameterDetail[] PARAMS =
+		{
+		};
+
+		public IEnumerable<ParameterDetail> DescribeParameters()
+		{
+			return PARAMS;
+		}
+
+		public bool IsSupported(Challenge c)
+		{
+			return c is DnsChallenge;
+		}
+
+		public IChallengeHandler GetHandler(Challenge c, IReadOnlyDictionary<string, object> initParams)
+		{
+			var h = new MSDNSChallengeHandler();
+
+			return h;
+		}
+	}
+}

--- a/ACMESharp/ACMESharp/ACMESharp.csproj
+++ b/ACMESharp/ACMESharp/ACMESharp.csproj
@@ -57,6 +57,7 @@
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Management" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
@@ -94,6 +95,8 @@
     <Compile Include="ACME\Providers\HttpChallengeDecoderProvider.cs" />
     <Compile Include="ACME\Providers\ManualChallengeHandler.cs" />
     <Compile Include="ACME\Providers\ManualChallengeHandlerProvider.cs" />
+    <Compile Include="ACME\Providers\MSDNSChallengeHandler.cs" />
+    <Compile Include="ACME\Providers\MSDNSChallengeHandlerProvider.cs" />
     <Compile Include="Certificate.cs" />
     <Compile Include="AuthorizationState.cs" />
     <Compile Include="CertificateRequest.cs" />


### PR DESCRIPTION
This provider uses WMI to auto-complete DNS challenges when using Microsoft DNS server.  It does not currently support cleaning up rows, but will alter existing TXT records rather than create additional ones on subsequent validations of a host name.  It only currently works when running on the machine that runs DNS, though it should be possible to extend it to work with a remote DNS as long as it is available via WMI.