### PR TITLE
Add new cmdlets. Return null instead of throwing error for GetRegistration

### DIFF
--- a/ACMESharp/ACMESharp.POSH/ACMESharp.POSH.csproj
+++ b/ACMESharp/ACMESharp.POSH/ACMESharp.POSH.csproj
@@ -59,6 +59,8 @@
     <Compile Include="..\shared\SharedGlobalSuppressions.cs">
       <Link>Properties\SharedGlobalSuppressions.cs</Link>
     </Compile>
+    <Compile Include="RevokeCertificate.cs" />
+    <Compile Include="RemoveCertificate.cs" />
     <Compile Include="RemoveIdentifier.cs" />
     <Compile Include="GetCertificate.cs" />
     <Compile Include="GetChallengeHandlerProfile.cs" />

--- a/ACMESharp/ACMESharp.POSH/ACMESharp.POSH.csproj
+++ b/ACMESharp/ACMESharp.POSH/ACMESharp.POSH.csproj
@@ -59,6 +59,7 @@
     <Compile Include="..\shared\SharedGlobalSuppressions.cs">
       <Link>Properties\SharedGlobalSuppressions.cs</Link>
     </Compile>
+    <Compile Include="RemoveIdentifier.cs" />
     <Compile Include="GetCertificate.cs" />
     <Compile Include="GetChallengeHandlerProfile.cs" />
     <Compile Include="GetIdentifier.cs" />

--- a/ACMESharp/ACMESharp.POSH/GetRegistration.cs
+++ b/ACMESharp/ACMESharp.POSH/GetRegistration.cs
@@ -17,14 +17,18 @@ namespace ACMESharp.POSH
             {
                 vlt.OpenStorage();
                 var v = vlt.LoadVault();
-                
+
                 if (v.Registrations == null || v.Registrations.Count < 1)
-                    throw new InvalidOperationException("No registrations found");
+                {
+                    WriteObject(null);
+                }
+                else
+                {
+                    var ri = v.Registrations[0];
+                    var r = ri.Registration;
 
-                var ri = v.Registrations[0];
-                var r = ri.Registration;
-
-                WriteObject(r);
+                    WriteObject(r);
+                }
             }
         }
     }

--- a/ACMESharp/ACMESharp.POSH/RemoveCertificate.cs
+++ b/ACMESharp/ACMESharp.POSH/RemoveCertificate.cs
@@ -1,0 +1,62 @@
+﻿using ACMESharp.Vault;
+using System;
+using System.Linq;
+using System.Management.Automation;
+
+namespace ACMESharp.POSH
+{
+    [Cmdlet(VerbsCommon.Remove, "Certificate")]
+    public class RemoveCertificate : Cmdlet
+    {
+        [Parameter(Mandatory = true, Position = 0)]
+        [Alias("Ref")]
+        public string CertificateRef
+        { get; set; }
+
+        [Parameter]
+        public string VaultProfile
+        { get; set; }
+
+        protected override void ProcessRecord()
+        {
+            using (var vlt = Util.VaultHelper.GetVault(VaultProfile))
+            {
+                vlt.OpenStorage();
+                var v = vlt.LoadVault();
+
+                if (v.Registrations == null || v.Registrations.Count < 1)
+                    throw new InvalidOperationException("No registrations found");
+
+                var ri = v.Registrations[0];
+                var r = ri.Registration;
+
+                if (v.Certificates == null || v.Certificates.Count < 1)
+                    throw new InvalidOperationException("No certificates found");
+
+                var ci = v.Certificates.GetByRef(CertificateRef, throwOnMissing: false);
+                if (ci == null)
+                {
+                    throw new ItemNotFoundException("Unable to find a Certificate for the given reference");
+                }
+                else
+                {
+                    v.Certificates.Remove(ci.Id);
+
+                    // remove files
+                    var keyGenFile = $"{ci.Id}-gen-key.json";
+                    var csrGenFile = $"{ci.Id}-gen-csr.json";
+
+                    vlt.RemoveAsset(VaultAssetType.CsrDetails, ci.GenerateDetailsFile);
+                    vlt.RemoveAsset(VaultAssetType.KeyGen, keyGenFile);
+                    vlt.RemoveAsset(VaultAssetType.KeyPem, ci.KeyPemFile);
+                    vlt.RemoveAsset(VaultAssetType.CsrGen, csrGenFile);
+                    vlt.RemoveAsset(VaultAssetType.CsrPem, ci.CsrPemFile);
+                    vlt.RemoveAsset(VaultAssetType.CrtPem, ci.CrtPemFile);
+                    vlt.RemoveAsset(VaultAssetType.CrtDer, ci.CrtDerFile);
+                }
+
+                vlt.SaveVault(v);
+            }
+        }
+    }
+}

--- a/ACMESharp/ACMESharp.POSH/RemoveIdentifier.cs
+++ b/ACMESharp/ACMESharp.POSH/RemoveIdentifier.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Linq;
+using System.Management.Automation;
+
+namespace ACMESharp.POSH
+{
+    [Cmdlet(VerbsCommon.Remove, "Identifier")]
+    public class RemoveIdentifier : Cmdlet
+    {
+        [Parameter(Mandatory = true, Position = 0)]
+        [Alias("Ref")]
+        public string IdentifierRef
+        { get; set; }
+
+        [Parameter]
+        public string VaultProfile
+        { get; set; }
+
+        protected override void ProcessRecord()
+        {
+            using (var vlt = Util.VaultHelper.GetVault(VaultProfile))
+            {
+                vlt.OpenStorage();
+                var v = vlt.LoadVault();
+
+                if (v.Identifiers == null || v.Identifiers.Count < 1)
+                {
+                    // throw because none exist (and thus, we couldn't find the one specified)
+                    throw new ItemNotFoundException("No Identifiers found");
+                }
+                else
+                {
+                    var ii = v.Identifiers.GetByRef(IdentifierRef, throwOnMissing: false);
+                    if (ii == null)
+                    {
+                        throw new ItemNotFoundException("Unable to find an Identifier for the given reference");
+                    }
+                    else
+                    {
+                        v.Identifiers.Remove(ii.Id);
+                    }
+                    vlt.SaveVault(v);
+                }
+            }
+        }
+    }
+}

--- a/ACMESharp/ACMESharp.POSH/RevokeCertificate.cs
+++ b/ACMESharp/ACMESharp.POSH/RevokeCertificate.cs
@@ -1,0 +1,83 @@
+﻿using ACMESharp.Vault.Model;
+using ACMESharp.POSH.Util;
+using System;
+using System.Linq;
+using System.Management.Automation;
+
+namespace ACMESharp.POSH
+{
+    [Cmdlet("Revoke", "Certificate")]
+    public class RevokeCertificate : Cmdlet
+    {
+        [Parameter(Mandatory = true, Position = 0)]
+        [Alias("Ref")]
+        public string CertificateRef
+        { get; set; }
+
+        [Parameter]
+        [ValidateSet("unspecified", "keyCompromise", "superseded")]
+        public string Reason
+        { get; set; } = "unspecified";
+
+        [Parameter]
+        public string VaultProfile
+        { get; set; }
+
+        protected override void ProcessRecord()
+        {
+            using (var vlt = Util.VaultHelper.GetVault(VaultProfile))
+            {
+                vlt.OpenStorage();
+                var v = vlt.LoadVault();
+
+                if (v.Registrations == null || v.Registrations.Count < 1)
+                    throw new InvalidOperationException("No registrations found");
+
+                var ri = v.Registrations[0];
+                var r = ri.Registration;
+
+                if (v.Certificates == null || v.Certificates.Count < 1)
+                    throw new InvalidOperationException("No certificates found");
+
+                var ci = v.Certificates.GetByRef(CertificateRef, throwOnMissing: false);
+                if (ci == null)
+                    throw new ItemNotFoundException("Unable to find a Certificate for the given reference");
+
+                if (ci.CertificateRequest == null)
+                    throw new Exception("Certificate has not been submitted yet; cannot revoke the certificate");
+
+                // Revoke ACME certificate
+                try
+                {
+                    using (var c = ClientHelper.GetClient(v, ri))
+                    {
+                        c.Init();
+                        c.GetDirectory(true);
+
+                        var reasonCode = 0;
+                        switch (Reason)
+                        {
+                            case "keyCompromise":
+                                reasonCode = 1;
+                                break;
+                            case "superseded":
+                                reasonCode = 4;
+                                break;
+                            default:
+                                reasonCode = 0;
+                                break;
+                        }
+                        c.RevokeCertificate(ci.CertificateRequest.CertificateContent, reasonCode);
+                    }
+                }
+                catch (AcmeClient.AcmeWebException ex)
+                {
+                    ThrowTerminatingError(PoshHelper.CreateErrorRecord(ex, ci));
+                    return;
+                }
+
+                WriteObject(null);
+            }
+        }
+    }
+}

--- a/ACMESharp/ACMESharp.Vault/IVault.cs
+++ b/ACMESharp/ACMESharp.Vault/IVault.cs
@@ -39,7 +39,9 @@ namespace ACMESharp.Vault
                 bool getOrCreate = false);
     
         VaultAsset GetAsset(VaultAssetType type, string name);
-    
+
+        void RemoveAsset(VaultAssetType type, string name);
+
         Stream SaveAsset(VaultAsset asset);
     
         Stream LoadAsset(VaultAsset asset);

--- a/ACMESharp/ACMESharp.Vault/Providers/LocalDiskVault.cs
+++ b/ACMESharp/ACMESharp.Vault/Providers/LocalDiskVault.cs
@@ -267,6 +267,19 @@ namespace ACMESharp.Vault.Providers
                     File.GetAttributes(path).HasFlag(FileAttributes.Encrypted));
         }
 
+        public void RemoveAsset(VaultAssetType type, string name)
+        {
+            if (!string.IsNullOrEmpty(name))
+            {
+                var path = Path.Combine(RootPath, TYPE_PATHS[type], name);
+
+                if (File.Exists(path))
+                {
+                    File.Delete(path);
+                }
+            }
+        }
+
         public Stream SaveAsset(VaultAsset asset)
         {
             var va = (FileVaultAsset)asset;

--- a/ACMESharp/ACMESharp/ACMESharp.csproj
+++ b/ACMESharp/ACMESharp/ACMESharp.csproj
@@ -133,6 +133,7 @@
     <Compile Include="Messages\NewCertRequest.cs" />
     <Compile Include="Messages\ProblemDetailResponse.cs" />
     <Compile Include="Messages\RegResponse.cs" />
+    <Compile Include="Messages\RevokeCertRequest.cs" />
     <Compile Include="Messages\UpdateRegRequest.cs" />
     <Compile Include="Messages\AnswerHttpChallengeRequest.cs" />
     <Compile Include="PKI\Crt.cs" />

--- a/ACMESharp/ACMESharp/AcmeClient.cs
+++ b/ACMESharp/ACMESharp/AcmeClient.cs
@@ -622,6 +622,28 @@ namespace ACMESharp
             }
         }
 
+        public void RevokeCertificate(string certificateData, int reason)
+        {
+            AssertInit();
+            AssertRegistration();
+
+            var revMsg = new RevokeCertRequest
+            {
+                Certificate = certificateData,
+                Reason = reason
+            };
+
+            var resp = RequestHttpPost(new Uri(RootUrl,
+                    Directory[AcmeServerDirectory.RES_REVOKE_CERT]), revMsg);
+
+            if (resp.IsError)
+                throw new AcmeWebException(resp.Error as WebException,
+                        "Unexpected error", resp);
+
+            if (resp.StatusCode != HttpStatusCode.OK)
+                throw new AcmeProtocolException("Unexpected response status code", resp);
+        }
+
         private AcmeHttpResponse RequestHttpGet(Uri uri)
         {
             var requ = (HttpWebRequest)WebRequest.Create(uri);

--- a/ACMESharp/ACMESharp/Messages/RevokeCertRequest.cs
+++ b/ACMESharp/ACMESharp/Messages/RevokeCertRequest.cs
@@ -1,0 +1,14 @@
+﻿namespace ACMESharp.Messages
+{
+    public class RevokeCertRequest : RequestMessage
+    {
+        public RevokeCertRequest() : base("revoke-cert")
+        { }
+
+        public string Certificate
+        { get; set; }
+
+        public int Reason
+        { get; set; }
+    }
+}


### PR DESCRIPTION
Add new cmdlets:
- Remove-AcmeIdentifier: removes an identifier from vault
- Revoke-AcmeCertificate: revokes an certificate from Let's Encrypt
- Remove-AcmeCertificate: removes an certificate from vault and all the related files

Return null instead of throwing error for GetRegistration