### PR TITLE
[WIP] Allow customization of RSA ProviderType and ProviderName

### DIFF
--- a/ACMESharp/ACMESharp.PKI.Providers.BouncyCastle/BouncyCastleProvider.cs
+++ b/ACMESharp/ACMESharp.PKI.Providers.BouncyCastle/BouncyCastleProvider.cs
@@ -431,7 +431,6 @@ namespace ACMESharp.PKI.Providers
             if (rsaPkParams != null && rsaPkParams.ProviderType != null)
             {
                 cspParameters.ProviderType = rsaPkParams.ProviderType.Value;
-                cspParameters.ProviderName = rsaPkParams.ProviderName;
             }
 
             RSACryptoServiceProvider rsaProvider = new RSACryptoServiceProvider(cspParameters);

--- a/ACMESharp/ACMESharp/PKI/RSA/RsaPrivateKeyParams.cs
+++ b/ACMESharp/ACMESharp/PKI/RSA/RsaPrivateKeyParams.cs
@@ -39,12 +39,5 @@ namespace ACMESharp.PKI.RSA
         /// </summary>
         public int? ProviderType
         { get; set; }
-
-        /// <summary>
-        /// Possible values listed in
-        /// HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Cryptography\Defaults\Provider
-        /// </summary>
-        public string ProviderName
-        { get; set; }
     }
 }

--- a/ACMESharp/ACMESharp/PKI/RSA/RsaPrivateKeyParams.cs
+++ b/ACMESharp/ACMESharp/PKI/RSA/RsaPrivateKeyParams.cs
@@ -32,5 +32,19 @@ namespace ACMESharp.PKI.RSA
 
         public object CallbackArg
         { get; set; }
+
+        /// <summary>
+        /// Possible values listed in
+        /// HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Cryptography\Defaults\Provider
+        /// </summary>
+        public int? ProviderType
+        { get; set; }
+
+        /// <summary>
+        /// Possible values listed in
+        /// HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Cryptography\Defaults\Provider
+        /// </summary>
+        public string ProviderName
+        { get; set; }
     }
 }


### PR DESCRIPTION
This would enable clients to better support specific use cases such as older versions of Microsoft Exchange.

Note that while the key bit has been tested in LEWS, the integration into ACMESharp is **untested** as I haven't been able to do a full build of the solution yet. The PR is meant for inspiration.