### PR TITLE
Request Header Updates (User-Agent, Accept-Language)

### DIFF
--- a/ACMESharp/ACMESharp/AcmeClient.cs
+++ b/ACMESharp/ACMESharp/AcmeClient.cs
@@ -52,7 +52,7 @@ namespace ACMESharp
         #region -- Properties --
 
         public string UserAgent
-        { get; private set; }
+        { get; set; }
 
         public Uri RootUrl
         { get; set; }

--- a/ACMESharp/ACMESharp/AcmeClient.cs
+++ b/ACMESharp/ACMESharp/AcmeClient.cs
@@ -54,6 +54,9 @@ namespace ACMESharp
         public string UserAgent
         { get; set; }
 
+        public string Language
+        { get; set; }
+
         public Uri RootUrl
         { get; set; }
 
@@ -634,7 +637,9 @@ namespace ACMESharp
             if (Proxy != null)
                 requ.Proxy = Proxy;
             requ.Method = AcmeProtocol.HTTP_METHOD_GET;
-            requ.UserAgent = this.UserAgent;
+            requ.UserAgent = UserAgent;
+            if (Language != null)
+                requ.Headers.Add(HttpRequestHeader.AcceptLanguage, Language);
 
             try
             {
@@ -692,7 +697,9 @@ namespace ACMESharp
             requ.Method = AcmeProtocol.HTTP_METHOD_POST;
             requ.ContentType = AcmeProtocol.HTTP_CONTENT_TYPE_JSON;
             requ.ContentLength = acmeBytes.Length;
-            requ.UserAgent = this.UserAgent;
+            requ.UserAgent = UserAgent;
+            if (Language != null)
+                requ.Headers.Add(HttpRequestHeader.AcceptLanguage, Language);
             try
             {
                 if (BeforeGetResponseAction != null)

--- a/ACMESharp/ACMESharp/AcmeProtocol.cs
+++ b/ACMESharp/ACMESharp/AcmeProtocol.cs
@@ -8,7 +8,7 @@
         public const string HTTP_METHOD_GET = "GET";
         public const string HTTP_METHOD_POST = "POST";
         public const string HTTP_CONTENT_TYPE_JSON = "application/json";
-        public const string HTTP_USER_AGENT_FMT = "ACMEdotNET v{0} (ACME 1.0)";
+        public const string HTTP_USER_AGENT_FMT = "ACMEdotNET/{0} (ACME 1.0)";
 
         public const string HEADER_REPLAY_NONCE = "Replay-nonce";
         public const string HEADER_LOCATION = "Location";


### PR DESCRIPTION
Allowed UserAgent to be set by users of the AcmeClient (per https://tools.ietf.org/html/draft-ietf-acme-acme-07#section-6.1 the ACME client should be set by the software).

Updated the AcmeProtocol.HTTP_USER_AGENT_FMT per RFC 7231 5.5.3 format, to use "/" instead of space and remove the "v".

Best practice would be for the AcmeClient users to simply append (or prepend) their User Agent string to the existing ACMEdotNET one, ex: "Certify/2.0.13 ACMEdotNET/0.9.0.323 (ACME 1.0)"