### PR TITLE
AcmeClient support for Certificate Revocation (revoke-cert)

### DIFF
--- a/ACMESharp/ACMESharp.Vault/Model/CertificateInfo.cs
+++ b/ACMESharp/ACMESharp.Vault/Model/CertificateInfo.cs
@@ -57,5 +57,8 @@ namespace ACMESharp.Vault.Model
 
         public string SignatureAlgorithm
         { get; set; }
+
+        public DateTime? RevokedAt
+        { get; set; }
     }
 }

--- a/ACMESharp/ACMESharp/ACMESharp.csproj
+++ b/ACMESharp/ACMESharp/ACMESharp.csproj
@@ -131,6 +131,7 @@
     <Compile Include="Messages\NewCertRequest.cs" />
     <Compile Include="Messages\ProblemDetailResponse.cs" />
     <Compile Include="Messages\RegResponse.cs" />
+    <Compile Include="Messages\RevokeCertRequest.cs" />
     <Compile Include="Messages\UpdateRegRequest.cs" />
     <Compile Include="Messages\AnswerHttpChallengeRequest.cs" />
     <Compile Include="PKI\Crt.cs" />

--- a/ACMESharp/ACMESharp/AcmeClient.cs
+++ b/ACMESharp/ACMESharp/AcmeClient.cs
@@ -628,6 +628,33 @@ namespace ACMESharp
             }
         }
 
+        public AcmeHttpResponse RevokeCertificate(string certificate)
+        {
+            AssertInit();
+            AssertRegistration();
+
+            var revoMsg = new RevokeCertRequest()
+            {
+                Certificate = certificate
+            };
+
+            var resp = RequestHttpPost(new Uri(RootUrl,
+                    Directory[AcmeServerDirectory.RES_REVOKE_CERT]), revoMsg);
+
+            // HttpStatusCode.Conflict (409) is returned if cert is already revoked
+            if (resp.StatusCode == HttpStatusCode.Conflict)
+                throw new AcmeProtocolException("Certificate already revoked", resp);
+
+            if (resp.IsError)
+                throw new AcmeWebException(resp.Error as WebException,
+                        "Unexpected error", resp);
+
+            if (resp.StatusCode != HttpStatusCode.OK)
+                throw new AcmeProtocolException("Unexpected response status code", resp);
+
+            return resp;
+        }
+
         private AcmeHttpResponse RequestHttpGet(Uri uri)
         {
             var requ = (HttpWebRequest)WebRequest.Create(uri);

--- a/ACMESharp/ACMESharp/Messages/RevokeCertRequest.cs
+++ b/ACMESharp/ACMESharp/Messages/RevokeCertRequest.cs
@@ -1,0 +1,11 @@
+﻿namespace ACMESharp.Messages
+{
+    public class RevokeCertRequest : RequestMessage
+    {
+        public RevokeCertRequest() : base(AcmeServerDirectory.RES_REVOKE_CERT)
+        { }
+
+        public string Certificate
+        { get; set; }
+    }
+}


### PR DESCRIPTION
* Pass the issued cert string (ex: `[CertificateInfo instance].CertificateRequest.CertificateContent`) to the `AcmeClient.RevokeCertificate` function
* Request can be signed with the account key pair or the key pair in the certificate, depending on the `AcmeClient.Signer` property. (see [relevant spec](https://tools.ietf.org/html/draft-ietf-acme-acme-07#section-7.6))
* Tested by revoking a cert and checking the OCSP [with openssl](https://raymii.org/s/articles/OpenSSL_Manually_Verify_a_certificate_against_an_OCSP.html) and verifying with [SSL Labs test](https://www.ssllabs.com/ssltest/).
* Partially addresses #103 and #57 (you'll probably want to add support to the Powershell commands)