### PR TITLE
Fix NullReferenceException when ACMESharp.dll is packed into .exe file

### DIFF
--- a/ACMESharp/ACMESharp/Ext/ExtCommon.cs
+++ b/ACMESharp/ACMESharp/Ext/ExtCommon.cs
@@ -41,11 +41,11 @@ namespace ACMESharp.Ext
         {
             var thisAsm = Assembly.GetExecutingAssembly().Location;
             if (string.IsNullOrEmpty(thisAsm))
-                return null;
+                return EMPTY_STRING_ARRAY;
 
             var thisDir = Path.GetFullPath(Path.GetDirectoryName(thisAsm));
             if (string.IsNullOrEmpty(thisDir))
-                return null;
+                return EMPTY_STRING_ARRAY;
 
 			return (ExtensionPaths ?? EMPTY_STRING_ARRAY).Select(x => x.StartsWith("~/")
 					? Path.Combine(thisDir, x.Substring(2))


### PR DESCRIPTION
We ran into this in LEWS https://github.com/Lone-Coder/letsencrypt-win-simple/issues/592