### PR TITLE
Fix PFX Export (#288 and Improve #283)

### DIFF
--- a/ACMESharp/ACMESharp.PKI.Providers.BouncyCastle/BouncyCastleProvider.cs
+++ b/ACMESharp/ACMESharp.PKI.Providers.BouncyCastle/BouncyCastleProvider.cs
@@ -377,10 +377,8 @@ namespace ACMESharp.PKI.Providers
                 var bcPk = FromPrivatePem(rsaPk.Pem);
 
                 var pfx = new Pkcs12Store();
-				//pfx.SetCertificateEntry(bcCerts[0].Certificate.ToString(), bcCerts[0]);
-				//pfx.SetKeyEntry(bcCerts[0].Certificate.ToString(),
-				pfx.SetCertificateEntry(string.Empty, bcCerts[0]);
-				pfx.SetKeyEntry(string.Empty,
+				pfx.SetCertificateEntry(bcCerts[0].Certificate.SubjectDN.ToString(), bcCerts[0]);
+				pfx.SetKeyEntry(bcCerts[0].Certificate.SubjectDN.ToString(),
 						new AsymmetricKeyEntry(bcPk.Private), new[] { bcCerts[0] });
 
                 for (int i = 1; i < bcCerts.Length; ++i)
@@ -390,25 +388,7 @@ namespace ACMESharp.PKI.Providers
                 }
 
 				// It used to be pretty straight forward to export this...
-				//pfx.Save(target, password?.ToCharArray(), new SecureRandom());
-
-				// ...unfortunately, BC won't let us export the Pkcs12 archive
-				// without assigning a FriendlyName, so we have to export and
-				// then re-import it, clear the FriendlyName, then return that
-				// YUCK!
-				using (var tmp = new MemoryStream())
-				{
-					pfx.Save(tmp, null, new SecureRandom());
-					var c = new System.Security.Cryptography.X509Certificates.X509Certificate2();
-					c.Import(tmp.ToArray(), string.Empty, 
-							System.Security.Cryptography.X509Certificates.X509KeyStorageFlags.PersistKeySet |
-							System.Security.Cryptography.X509Certificates.X509KeyStorageFlags.Exportable);
-
-					// Clear the FriendlyName
-					c.FriendlyName = null;
-					var bytes = c.Export(System.Security.Cryptography.X509Certificates.X509ContentType.Pkcs12, password);
-					target.Write(bytes, 0, bytes.Length);
-				}
+				pfx.Save(target, password?.ToCharArray(), new SecureRandom());
 			}
             else
             {


### PR DESCRIPTION
Your initial version was good, expect the Alias was refering to the certificate object (`bcCerts[0].Certificate.ToString()`), and that cause the issue #283.  By using the subject as Alias (which becomes the Friendlyname for Windows), that solve also the issue #288 by avoiding the dirty hack to re-export the certificate.   The native pfx.save work as expected and the pfx is now clean.

