### PR TITLE
TLS-SNI Challenge

### DIFF
--- a/ACMESharp/ACMESharp/ACME/Providers/ManualChallengeHandlerProvider.cs
+++ b/ACMESharp/ACMESharp/ACME/Providers/ManualChallengeHandlerProvider.cs
@@ -60,7 +60,7 @@ namespace ACMESharp.ACME.Providers
 
         public bool IsSupported(Challenge c)
         {
-            return c is DnsChallenge || c is HttpChallenge;
+            return c is DnsChallenge || c is HttpChallenge || c is TlsSniChallenge;
         }
 
         public IChallengeHandler GetHandler(Challenge c, IReadOnlyDictionary<string, object> initParams)

--- a/ACMESharp/ACMESharp/ACME/Providers/TlsSniChallengeDecoder.cs
+++ b/ACMESharp/ACMESharp/ACME/Providers/TlsSniChallengeDecoder.cs
@@ -1,0 +1,52 @@
+﻿using ACMESharp.JOSE;
+using ACMESharp.Messages;
+using ACMESharp.Util;
+using NLog;
+using System.IO;
+
+namespace ACMESharp.ACME.Providers
+{
+    public class TlsSniChallengeDecoder : IChallengeDecoder
+    {
+        private static readonly Logger LOG = LogManager.GetCurrentClassLogger();
+
+        public bool IsDisposed
+        { get; private set; }
+
+        public Challenge Decode(IdentifierPart ip, ChallengePart cp, ISigner signer)
+        {
+            if (cp.Type != AcmeProtocol.CHALLENGE_TYPE_SNI)
+                throw new InvalidDataException("unsupported Challenge type")
+                    .With("challengeType", cp.Type)
+                    .With("supportedChallengeTypes", AcmeProtocol.CHALLENGE_TYPE_SNI);
+
+            //var token = (string)cp["token"];
+            var token = cp.Token;
+
+            // This response calculation is described in:
+            //    https://tools.ietf.org/html/draft-ietf-acme-acme-01#section-7.5
+
+            var keyAuthz = JwsHelper.ComputeKeyAuthorization(signer, token);
+            var keyAuthzDig = JwsHelper.ComputeKeyAuthorizationDigest(signer, token);
+
+            LOG.Debug("Computed key authorization {0} and digest {1}", keyAuthz, keyAuthzDig);
+
+            var ca = new TlsSniChallengeAnswer
+            {
+                KeyAuthorization = keyAuthz,
+            };
+
+            var c = new TlsSniChallenge(cp.Type, ca)
+            {
+                Token = token
+            };
+
+            return c;
+        }
+
+        public void Dispose()
+        {
+            IsDisposed = true;
+        }
+    }
+}

--- a/ACMESharp/ACMESharp/ACME/Providers/TlsSniChallengeDecoder.cs
+++ b/ACMESharp/ACMESharp/ACME/Providers/TlsSniChallengeDecoder.cs
@@ -20,11 +20,10 @@ namespace ACMESharp.ACME.Providers
                     .With("challengeType", cp.Type)
                     .With("supportedChallengeTypes", AcmeProtocol.CHALLENGE_TYPE_SNI);
 
-            //var token = (string)cp["token"];
             var token = cp.Token;
 
             // This response calculation is described in:
-            //    https://tools.ietf.org/html/draft-ietf-acme-acme-01#section-7.5
+            //    https://tools.ietf.org/html/draft-ietf-acme-acme-01#section-7.3
 
             var keyAuthz = JwsHelper.ComputeKeyAuthorization(signer, token);
             var keyAuthzDig = JwsHelper.ComputeKeyAuthorizationDigest(signer, token);
@@ -38,7 +37,8 @@ namespace ACMESharp.ACME.Providers
 
             var c = new TlsSniChallenge(cp.Type, ca)
             {
-                Token = token
+                Token = token,
+                IterationCount = 1 // see: https://github.com/ietf-wg-acme/acme/pull/22 for reason n=1
             };
 
             return c;

--- a/ACMESharp/ACMESharp/ACME/Providers/TlsSniChallengeDecoderProvider.cs
+++ b/ACMESharp/ACMESharp/ACME/Providers/TlsSniChallengeDecoderProvider.cs
@@ -1,0 +1,21 @@
+﻿using ACMESharp.Messages;
+
+namespace ACMESharp.ACME.Providers
+{
+    [ChallengeDecoderProvider(AcmeProtocol.CHALLENGE_TYPE_SNI, ChallengeTypeKind.TLS_SNI,
+        Description = "Challenge type decoder for the TLS-SNI type" +
+                      " as specified in" +
+                      " https://tools.ietf.org/html/draft-ietf-acme-acme-01#section-7.3")]
+    public class TlsSniChallengeDecoderProvider : IChallengeDecoderProvider
+    {
+        public bool IsSupported(IdentifierPart ip, ChallengePart cp)
+        {
+            return AcmeProtocol.CHALLENGE_TYPE_SNI == cp.Type;
+        }
+
+        public IChallengeDecoder GetDecoder(IdentifierPart ip, ChallengePart cp)
+        {
+            return new TlsSniChallengeDecoder();
+        }
+    }
+}

--- a/ACMESharp/ACMESharp/ACMESharp.csproj
+++ b/ACMESharp/ACMESharp/ACMESharp.csproj
@@ -94,6 +94,8 @@
     <Compile Include="ACME\Providers\HttpChallengeDecoderProvider.cs" />
     <Compile Include="ACME\Providers\ManualChallengeHandler.cs" />
     <Compile Include="ACME\Providers\ManualChallengeHandlerProvider.cs" />
+    <Compile Include="ACME\Providers\TlsSniChallengeDecoder.cs" />
+    <Compile Include="ACME\Providers\TlsSniChallengeDecoderProvider.cs" />
     <Compile Include="ACME\Providers\DnsMadeEasyChallengeHandler.cs" />
     <Compile Include="ACME\Providers\DnsMadeEasyChallengeHandlerProvider.cs" />
     <Compile Include="Certificate.cs" />

--- a/ACMESharp/ACMESharp/AcmeProtocol.cs
+++ b/ACMESharp/ACMESharp/AcmeProtocol.cs
@@ -37,7 +37,7 @@
         /// <summary>
         /// Identifier validation challenge type indicator for
         /// <see cref="https://tools.ietf.org/html/draft-ietf-acme-acme-01#section-7.3"
-        /// >TLS SNI</see>.  Currently UNSUPPORTED.
+        /// >TLS SNI</see>.
         /// </summary>
         public const string CHALLENGE_TYPE_SNI = "tls-sni-01";
         /// <summary>


### PR DESCRIPTION
Same commits from #295 (minus the [reverted](https://github.com/ebekker/ACMESharp/pull/295/commits/64338036b6b68c1faa0530a16eabe5074cd9892d) [commit](https://github.com/ebekker/ACMESharp/pull/295/commits/cd7927e5cff0f3e4f35f86c3e614650b917ace48)) rebased onto current master.