### PR TITLE
Cloudflare: Enable TLS 1.2

### DIFF
--- a/ACMESharp/ACMESharp.Providers.CloudFlare/CloudFlareHelper.cs
+++ b/ACMESharp/ACMESharp.Providers.CloudFlare/CloudFlareHelper.cs
@@ -31,6 +31,9 @@ namespace ACMESharp.Providers.CloudFlare
             _authKey = authKey;
             _emailAddress = emailAddress;
             _domainName = domainName;
+            
+            // Cloudflare requires at least TLS 1.2.
+            System.Net.ServicePointManager.SecurityProtocol = System.Net.SecurityProtocolType.Tls12;
         }
 
         private HttpRequestMessage CreateRequest(HttpMethod method, string url)


### PR DESCRIPTION
Cloudflare requires TLS 1.2. If TLS 1.2 is not forced, .NET uses TLS 1.1 and the request to Cloudflare fails.