### PR TITLE
#352 - Allow sslFlags to remain unchanged.

### DIFF
--- a/ACMESharp/ACMESharp.Providers.IIS/IisHelper.cs
+++ b/ACMESharp/ACMESharp.Providers.IIS/IisHelper.cs
@@ -94,7 +94,7 @@ namespace ACMESharp.Providers.IIS
             }
         }
 
-        public static void UpdateSiteBinding(IisWebSiteBinding binding, string certStore, byte[] certHash)
+        public static void UpdateSiteBinding(IisWebSiteBinding binding, string certStore, byte[] certHash, bool keepExistingSslFlags = false)
         {
             using (var iis = new ServerManager())
             {
@@ -120,10 +120,13 @@ namespace ACMESharp.Providers.IIS
                         ++bindingCount;
                         b.CertificateStoreName = certStore;
                         b.CertificateHash = certHash;
-                        if (binding.BindingHostRequired.GetValueOrDefault() && GetIisVersion().Major >= 8)
-                            b.SetAttributeValue("sslFlags", 1);
-                        else
-                            b.SetAttributeValue("sslFlags", 3);
+                        if (!keepExistingSslFlags) 
+                        {
+                            if (binding.BindingHostRequired.GetValueOrDefault() && GetIisVersion().Major >= 8)
+                                b.SetAttributeValue("sslFlags", 1);
+                            else
+                                b.SetAttributeValue("sslFlags", 3);
+                        }
                     }
                 }
 

--- a/ACMESharp/ACMESharp.Providers.IIS/IisInstaller.cs
+++ b/ACMESharp/ACMESharp.Providers.IIS/IisInstaller.cs
@@ -45,6 +45,9 @@ namespace ACMESharp.Providers.IIS
         public bool Force
         { get; set; }
 
+        public bool KeepExistingSslFlags
+        { get; set; }
+
         public string CertificateFriendlyName
         { get; set; }
 
@@ -82,7 +85,7 @@ namespace ACMESharp.Providers.IIS
                 {
                     if (BindingHostRequired.HasValue)
                         oldBinding.BindingHostRequired = BindingHostRequired;
-                    IisHelper.UpdateSiteBinding(oldBinding, certStore, certHash);
+                    IisHelper.UpdateSiteBinding(oldBinding, certStore, certHash, keepExistingSslFlags: KeepExistingSslFlags);
                 }
             }
             else


### PR DESCRIPTION
Added a property, KeepExistingSslFlags, to the IisInstaller to allow people to run `Install-ACMECertificate` with `Force = $true` without triggering the Centralized Certificate Store.  This is done by including `KeepExistingSslFlags = $true;` to the `InstallerParameters` argument.

